### PR TITLE
using programs --  breathing room, delineation, linking

### DIFF
--- a/docs/use/cron.md
+++ b/docs/use/cron.md
@@ -1,6 +1,6 @@
 DETA allows you to schedule programs to run periodically, providing two ways of doing so: `rate` epressions and `cron` expressions.
 
-*To change the schedule settings of a program, the program needs to be open (`open myprog`) in the [(Studio)](https://web.deta.sh/studio), and you need to have a ['full' access permission](../../permissions/).*
+*To change the schedule settings of a program, the program needs to be open (`open myprog`) in the [(Studio)](https://web.deta.sh/studio), and you need to have a ['full' access permission](/permissions/).*
 
 
 

--- a/docs/use/cron.md
+++ b/docs/use/cron.md
@@ -15,7 +15,7 @@ To set a program on a rate based execution schedule, follow this template:
 set -cron <interval> <unit>
 ```
 
-*The accepted unit values are **`minutes`**, **`hours`** and **`days`**. If the `interval` is `1`, use **`minute`**, **`hour`** or **`day`**.*
+*The accepted unit values are **`minutes`**, **`hours`** and **`days`**. If the `interval` is `1`, use **`minute`**, **`hour`** or **`day`** instead.*
 
 <br />
 

--- a/docs/use/cron.md
+++ b/docs/use/cron.md
@@ -1,16 +1,23 @@
-DETA allows you to schedule to program to run periodically. You have to methods of achieving tht:
+DETA allows you to schedule programs to run periodically, providing two ways of doing so: `rate` epressions and `cron` expressions.
 
-## Setting
+*To change the schedule settings of a program, the program needs to be open (`open myprog`) in the [(Studio)](https://web.deta.sh/studio), and you need to have a ['full' access permission](../../permissions/).*
+
+
+
+## Setting a Schedule
 ### 1) Rate expression (simple)
 
 Rate based scheduling will execute a program every `interval` according to the `unit`. 
-Usage is straight forward, just follow this template:
+
+To set a program on a rate based execution schedule, follow this template:
 
 ```ruby
 set -cron <interval> <unit>
 ```
 
-The accepted unit values are **`minutes`**, **`hours`** and **`days`**; or **`minute`**, **`hour`** and **`day`** If the `interval` is `1`.
+*The accepted unit values are **`minutes`**, **`hours`** and **`days`**. If the `interval` is `1`, use **`minute`**, **`hour`** or **`day`**.*
+
+<br />
 
 **Command examples**
 ```ruby
@@ -20,6 +27,8 @@ set -cron 1 day
 ```ruby
 set -cron 30 minutes
 ```
+
+<br />
 
 ### 2) Cron expression (advanced)
 ```ruby
@@ -38,16 +47,16 @@ set -cron <minute> <hour> <month_day> <week_day> <year>
 * **`#!rb set -cron 0/10 * ? * MON-FRI *`**: Run every 10 minutes Monday through Friday
 * **`#!rb set -cron 0/5 8-17 ? * MON-FRI *`**: Run every 5 minutes Monday through Friday between 8:00 am and 5:55 pm (UTC)
 
-## Checking
+## Checking a Schedule
 
-To check the Schedule setting for a specific program, simply run:
+To check if a program is set to run on a schedule, simply run:
 
 ```ruby
 ls -cron
 ```
 
-## Removing
-To unschedule running a program, simply run:
+## Removing a Schedule
+To stop a program from executing on a schedule, simply run:
 
 ```ruby
 rm -cron 

--- a/docs/use/http.md
+++ b/docs/use/http.md
@@ -22,7 +22,7 @@ There are 2 ways to authorize HTTP access to your program outside of DETA:
 2. API Keys
 
 
-**You can learn more about these 2 methods [here](/../../permissions/).**
+**You can learn more about these 2 methods [here](/permissions/).**
 
 ## Built-in HTTP client and Debugger
 

--- a/docs/use/http.md
+++ b/docs/use/http.md
@@ -1,9 +1,9 @@
-Using an HTTP endpoint is a great way to connect your program to the outside world.
-For example if you want to trigger it from another service (Webhook) or use it as a simple API endpoint.
+Every DETA program has its own HTTP endpoint, which is a great way to connect your program to the outside world.
+You can trigger it from another service (i.e. via webhooks) or use it as a simple API endpoint.
 
 ## URL
 
-Each program gets it's ***unique*** URL, which you can find when you click on the **VIEW** tab on the right of the Studio.:
+You can a program's ***unique*** URL by clicking on the **VIEW** tab on the right within the [Studio](https://web.deta.sh/studio):
 
 ![Finding the URL of a program](/images/url.png)
 
@@ -14,15 +14,15 @@ The URL looks something like this: **`https://app.deta.sh/abcdefg/`**
 
 ## Authentication
 
-If you copy the URL of freshly created program and paste it into your your browser, you would get this message instead of the expected response: `#!json {"errors":["Unauthorized"]}`.
+If you copy the URL of freshly created program and paste it into your your browser, instead of the expected response, you will get this message: `#!json {"errors":["Unauthorized"]}`.
 
-For now there are 2 convenient ways to authorize HTTP access to your program:
+There are 2 ways to authorize HTTP access to your program outside of DETA:
 
 1. Public Access (where you could implement your own auth functionality if needed)
 2. API Keys
 
 
-**You can learn more about these 2 methods [here](sharing.md)**
+**You can learn more about these 2 methods [here](/../../permissions/).**
 
 ## Built-in HTTP client and Debugger
 

--- a/docs/use/run.md
+++ b/docs/use/run.md
@@ -1,48 +1,71 @@
 DETA not only focuses on giving you a great experience writing programs,
-it also offers you a couple convenient way to interact with them.
+it also offers you a couple convenient ways to interact with them.
 
-## Using Teletype (CLI)
+## Using Teletype
 
-You can find Teletype (our command line interface) in 2 different places:
+You can find Teletype (DETA's command line interface) in 2 different places:
 
 ### 1) Teletype (Studio)
 
-To interact withy our programs in [Teletype (Studio)](https://web.deta.sh/studio), the program needs to be open (`open myprog`).
-To invoke the program, use the **command** `run` followed by an optional **action** then followed by the optional **kwargs** and **flags**.
+In the studio, where you can edit programs, the Teletype lets you quickly navigate, edit, and run your programs. A list of Studio Teletype commands is [here](../../teletype/).
+
+To run the program, use the **command** `run` followed by an **action** (optional) then followed by **kwargs** and **flags** (both optional).
+
+```ruby
+run <action> -<flag_one> --<kwarg_one> <kwarg_val_one>
+```
+*To run our programs in the [Teletype (Studio)](https://web.deta.sh/studio), the program needs to be open (`open myprog`) and you need to have a ['full' access permission](../../permissions/).*
+
+<br />
 
 **Command examples**
 
-Invoking the program with no additional arguments:
+Running the program:
 ```ruby
 run
 ```
-*This corresponds the with `@app.run()` decorated function. (Notice the lack of action)*
+*This corresponds the with [`@app.run()`](../../lib/run/) decorated function. (Notice the lack of action)*
 
-Invoking the program with arguments (but no action).
-```ruby
-run --name "Jean-Luc Picard" --origin France -likes_earl_gray_tea
-```
-*The data will be sent as JSON to your program. Flags (prefixed with '`-`') will be set to `true`.*
+<br />
 
-Invoke the program with and an **action**:
+Running the program with an **action**:
 
 ```ruby
 run add
 ```
+*This corresponds the with [`@app.run("add")`](../../lib/run/) decorated function. (Notice the "add" action)*
 
+<br />
+
+Running the program with arguments (but no **action**):
+```ruby
+run --name "Jean-Luc Picard" --origin France -likes_earl_gray_tea
+```
+*The data will be sent as JSON to your program. Flags (prefixed with `-`) will be set to `true`.*
+
+<br />
+
+Running the program with an **action** and arguments:
 ```ruby
 run add --name "Jean-Luc Picard" --origin France -likes_earl_gray_tea
 ```
-*This corresponds the with `@app.run("add")` decorated function. (Notice the "test" action)*
 
+<br />
 
 ### 2) Teletype (Dash)
 
-Teletype (Dash) offers you an even easier way to call your program. No need to open the program, just use the name of the program instead of the `run` command.
+The Dashboard's Teletype let's you run program without needing to `open` it. Just use the name of the program instead of the `run` command.
+
+```ruby
+<prog_name> <action> -<flag_one> --<kwarg_one> <kwarg_val_one>
+```
+
+*The Teletype (Dash) lets you run programs where you have a ['run' or 'full' access permission](../../permissions/).*
+
+<br />
 
 **Command examples**
 
 ```ruby
 st_captains add --name "Jean-Luc Picard" --origin France -likes_earl_gray_tea
 ```
-etc...

--- a/docs/use/run.md
+++ b/docs/use/run.md
@@ -33,7 +33,7 @@ Running the program with an **action**:
 ```ruby
 run add
 ```
-*This corresponds the with [`@app.run("add")`](../../lib/run/) decorated function. (Notice the "add" action)*
+*This corresponds the with [`@app.run("add")`](/lib/run/) decorated function. (Notice the "add" action)*
 
 <br />
 

--- a/docs/use/run.md
+++ b/docs/use/run.md
@@ -60,7 +60,7 @@ The Dashboard's Teletype let's you run program without needing to `open` it. Jus
 <prog_name> <action> -<flag_one> --<kwarg_one> <kwarg_val_one>
 ```
 
-*The Teletype (Dash) lets you run programs where you have a ['run' or 'full' access permission](../../permissions/).*
+*The Teletype (Dash) lets you run programs where you have a ['run' or 'full' access permission](/permissions/).*
 
 <br />
 

--- a/docs/use/run.md
+++ b/docs/use/run.md
@@ -24,7 +24,7 @@ Running the program:
 ```ruby
 run
 ```
-*This corresponds the with [`@app.run()`](../../lib/run/) decorated function. (Notice the lack of action)*
+*This corresponds the with [`@app.run()`](/lib/run/) decorated function. (Notice the lack of action)*
 
 <br />
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ nav:
   - Using your programs: 
     - Teletype (CLI): use/run.md
     - Schedule (cron): use/cron.md
-    - HTTP/Webhook: use/http.md
+    - HTTP / Webhook: use/http.md
   - DETA SDK (deta.lib):
     - Run (command line): lib/run.md
     - HTTP: lib/http.md
@@ -40,7 +40,7 @@ nav:
     - Cloud Files: resources/files.md
     - Email: resources/email.md
     - The Runtime: resources/runtime.md
-  - Sharing Programs (Video): sharing.md
+  - Permissions (Video): permissions.md
   - Debugging (Video): debug.md
   - Installing Packages: packages.md
   - Teletype Commands (CLI): teletype.md


### PR DESCRIPTION
Proposed modifications for the subsections under 'using':
- Tried to create a clearer conceptual separation between the Studio and Dash Teletype.
- Gave example commands more breathing room for separation.
- Added links and cleaned up Typos.