### PR TITLE
Fixes typo cron.md

### DIFF
--- a/docs/use/cron.md
+++ b/docs/use/cron.md
@@ -1,4 +1,4 @@
-DETA allows you to schedule programs to run periodically, providing two ways of doing so: `rate` epressions and `cron` expressions.
+DETA allows you to schedule programs to run periodically, providing two ways of doing so: `rate` expressions and `cron` expressions.
 
 *To change the schedule settings of a program, the program needs to be open (`open myprog`) in the [(Studio)](https://web.deta.sh/studio), and you need to have a ['full' access permission](/permissions/).*
 


### PR DESCRIPTION
Fixed a typo that says "epressions" instead of "expressions"